### PR TITLE
Bump source/target Java level

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,8 +90,8 @@
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Closes #14 

Now, after the tea, I think it shall be updated to 1.8.
In unlikely event of bugfix release needed for plugin 2.3, it can be made off that tag as 2.3.x.

WDYT about project's version? Should it be left as is or updated to 3.0-SNAPSHOT?