### PR TITLE
Make quietness of :check goal parameterized

### DIFF
--- a/src/main/java/org/glassfish/copyright/CheckCopyrightMojo.java
+++ b/src/main/java/org/glassfish/copyright/CheckCopyrightMojo.java
@@ -20,17 +20,21 @@ package org.glassfish.copyright;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Parameter;
 
 /**
  * Check copyrights of files.
  */
 @Mojo(name = "check", defaultPhase = LifecyclePhase.PROCESS_SOURCES)
 public class CheckCopyrightMojo extends AbstractCopyrightMojo {
+	@Parameter(property = "copyright.quiet", defaultValue = "true")
+	private boolean quiet;
+
     public void execute() throws MojoExecutionException {
 	log = getLog();
 
 	Copyright c = new Copyright();
-	c.quiet = true;
+	c.quiet = quiet;
 	initializeOptions(c);
 
 	check(c);


### PR DESCRIPTION
I propose to introduce parameter to configure if `:check` shall be quiet (now it is).
New parameter defaults to `true`, so if not set explicitly old behaviour is observed.

It would allow to reduce build work, for example in client [glassfish-build-maven-plugin:pom.xml#L176-L188:](https://github.com/eclipse-ee4j/glassfish-build-maven-plugin/blob/973c72a62aafabeae7d0c6940b5e714b0bb39cb5/pom.xml#L176-L188) two goals are executed:
```xml
            <plugin>
                <groupId>org.glassfish.copyright</groupId>
                <artifactId>glassfish-copyright-maven-plugin</artifactId>
                <executions>
                    <execution>
                        <goals>
                            <goal>copyright</goal>
                            <goal>check</goal>
                        </goals>
                        <phase>verify</phase>
                    </execution>
                </executions>
            </plugin>
```
where `:copyright` reports violations (but does not fail the build), while `:check` does not report violations but fails the build in case there is any. The work of `:check` and `:copyright` is almost the same and done twice is such case.
https://github.com/eclipse-ee4j/glassfish-copyright-plugin/blob/94c7ba4c6d3151b57f92cf030f77661f1ff15d17/src/main/java/org/glassfish/copyright/CheckCopyrightMojo.java#L29-L42 https://github.com/eclipse-ee4j/glassfish-copyright-plugin/blob/94c7ba4c6d3151b57f92cf030f77661f1ff15d17/src/main/java/org/glassfish/copyright/CopyrightMojo.java#L29-L36