### PR TITLE
Explicit log format for git

### DIFF
--- a/src/main/java/org/glassfish/copyright/AbstractCopyright.java
+++ b/src/main/java/org/glassfish/copyright/AbstractCopyright.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010, 2019 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020 Contributors to Eclipse Foundation. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -915,7 +916,7 @@ public abstract class AbstractCopyright {
 
     private static String lastChangedGit(String file) throws IOException {
         ProcessBuilder pb = new ProcessBuilder("git", "log", "-n", "1",
-            "--decorate", "--date=local", file);
+            "--decorate", "--date=local", "--format=medium", file);
         pb.redirectErrorStream(true);
         Process p = pb.start();
         p.getOutputStream().close();


### PR DESCRIPTION
https://git-scm.com/docs/pretty-formats
The log format might be altered by configuration, and some formats do not have "Date:" field.

In repository with different than default log format configured I currently get for example
```
.../Ordered.java: Copyright year is wrong; is 2017, should be 
```
(which is wrong and itself causes plenty of false-positives) and with this change:
```
.../Ordered.java: Copyright year is wrong; is 2017, should be 2018
```
which is correct.