### PR TITLE
Add explicit plugin-plugin version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -193,6 +193,11 @@
                         <additionalparam>${javadoc.options}</additionalparam>
                     </configuration>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-plugin-plugin</artifactId>
+                    <version>3.4</version>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
Currently this depends on the maven version used:

```
# maven 3.6.3:
[INFO] --- maven-plugin-plugin:3.2:addPluginArtifactMetadata 
```
```
# maven 3.9.9
[INFO] --- plugin:3.13.1:addPluginArtifactMetadata
```

- Picked `3.4` for the version used by `maven-plugin-annotations` dependency and following #28